### PR TITLE
feat: 타임리프 기반 단일 체크박스 처리 기능 적용

### DIFF
--- a/src/main/java/hello/itemservice/domain/item/ItemRepository.java
+++ b/src/main/java/hello/itemservice/domain/item/ItemRepository.java
@@ -32,6 +32,10 @@ public class ItemRepository {
         findItem.setItemName(updateParam.getItemName());
         findItem.setPrice(updateParam.getPrice());
         findItem.setQuantity(updateParam.getQuantity());
+        findItem.setOpen(updateParam.getOpen());
+        findItem.setRegions(updateParam.getRegions());
+        findItem.setItemType(updateParam.getItemType());
+        findItem.setDeliveryCode(updateParam.getDeliveryCode());
     }
 
     public void clearStore() {

--- a/src/main/resources/templates/form/addForm.html
+++ b/src/main/resources/templates/form/addForm.html
@@ -39,8 +39,7 @@
         <div>판매 여부</div>
         <div>
             <div class="form-check">
-                <input type="checkbox" id="open" name="open" class="form-check-input">
-                <input type="hidden" name="_open" value="on"/> <!-- 히든 필드 추가 -->
+                <input type="checkbox" id="open" th:field="*{open}" class="form-check-input">
                 <label for="open" class="form-check-label">판매 오픈</label>
             </div>
         </div>

--- a/src/main/resources/templates/form/editForm.html
+++ b/src/main/resources/templates/form/editForm.html
@@ -38,6 +38,15 @@
 
         <hr class="my-4">
 
+        <!-- single checkbox -->
+        <div>판매 여부</div>
+        <div>
+            <div class="form-check">
+                <input type="checkbox" id="open" th:field="*{open}" class="form-check-input">
+                <label for="open" class="form-check-label">판매 오픈</label>
+            </div>
+        </div>
+
         <div class="row">
             <div class="col">
                 <button class="w-100 btn btn-primary btn-lg" type="submit">저장</button>

--- a/src/main/resources/templates/form/item.html
+++ b/src/main/resources/templates/form/item.html
@@ -40,6 +40,15 @@
 
     <hr class="my-4">
 
+    <!-- single checkbox -->
+    <div>판매 여부</div>
+    <div>
+        <div class="form-check">
+            <input type="checkbox" id="open" th:field="${item.open}" class="form-check-input" disabled>
+            <label for="open" class="form-check-label">판매 오픈</label>
+        </div>
+    </div>
+
     <div class="row">
         <div class="col">
             <button class="w-100 btn btn-primary btn-lg"


### PR DESCRIPTION
### 작업 내용
- 타임리프의 th:field를 활용한 단일 체크박스 처리 기능 구현
- 판매 여부(open) 필드를 자동으로 바인딩하며, 체크 여부에 따라 true/false 처리
- 상세 페이지(item.html)에는 th:object 없이 ${item.open} 직접 참조
- 수정 폼(editForm.html)에도 동일한 방식 적용
- update 메서드에서 open 필드를 포함한 전체 필드 업데이트 처리