### PR TITLE
feat: 타임리프 기반 라디오 버튼(상품 종류) 처리 기능 추가

### DIFF
--- a/src/main/java/hello/itemservice/domain/item/ItemType.java
+++ b/src/main/java/hello/itemservice/domain/item/ItemType.java
@@ -8,4 +8,8 @@ public enum ItemType {
     ItemType(String description) {
         this.description = description;
     }
+
+    public String getDescription() {
+        return description;
+    }
 }

--- a/src/main/java/hello/itemservice/web/form/FormItemController.java
+++ b/src/main/java/hello/itemservice/web/form/FormItemController.java
@@ -2,6 +2,7 @@ package hello.itemservice.web.form;
 
 import hello.itemservice.domain.item.Item;
 import hello.itemservice.domain.item.ItemRepository;
+import hello.itemservice.domain.item.ItemType;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Controller;
@@ -30,6 +31,11 @@ public class FormItemController {
         return regions;
     }
 
+//    @ModelAttribute("itemTypes")
+//    public ItemType[] itemTypes() {
+//        return ItemType.values();
+//    }
+
     @GetMapping
     public String items(Model model) {
         List<Item> items = itemRepository.findAll();
@@ -56,6 +62,7 @@ public class FormItemController {
     public String addItem(@ModelAttribute Item item, RedirectAttributes redirectAttributes) {
         log.info("item.open={}", item.getOpen());
         log.info("item.regions={}", item.getRegions());
+        log.info("item.itemType={}", item.getItemType());
 
         Item savedItem = itemRepository.save(item);
         redirectAttributes.addAttribute("itemId", savedItem.getId());

--- a/src/main/resources/templates/form/addForm.html
+++ b/src/main/resources/templates/form/addForm.html
@@ -55,6 +55,19 @@
             </div>
         </div>
 
+        <!-- radio button -->
+        <div>
+            <div>상품 종류</div>
+            <div th:each="type : ${T(hello.itemservice.domain.item.ItemType).values()}" class="form-check form-check-inline">
+                <input type="radio" th:field="*{itemType}" th:value="${type.name()}"
+                       class="form-check-input">
+                <label th:for="${#ids.prev('itemType')}" th:text="${type.description}"
+                       class="form-check-label">
+                    BOOK
+                </label>
+            </div>
+        </div>
+
         <div class="row">
             <div class="col">
                 <button class="w-100 btn btn-primary btn-lg" type="submit">상품 등록</button>

--- a/src/main/resources/templates/form/editForm.html
+++ b/src/main/resources/templates/form/editForm.html
@@ -58,6 +58,19 @@
             </div>
         </div>
 
+        <!-- radio button -->
+        <div>
+            <div>상품 종류</div>
+            <div th:each="type : ${T(hello.itemservice.domain.item.ItemType).values()}" class="form-check form-check-inline">
+                <input type="radio" th:field="*{itemType}" th:value="${type.name()}"
+                       class="form-check-input">
+                <label th:for="${#ids.prev('itemType')}" th:text="${type.description}"
+                       class="form-check-label">
+                    BOOK
+                </label>
+            </div>
+        </div>
+
         <div class="row">
             <div class="col">
                 <button class="w-100 btn btn-primary btn-lg" type="submit">저장</button>

--- a/src/main/resources/templates/form/item.html
+++ b/src/main/resources/templates/form/item.html
@@ -60,6 +60,19 @@
         </div>
     </div>
 
+    <!-- radio button -->
+    <div>
+        <div>상품 종류</div>
+        <div th:each="type : ${T(hello.itemservice.domain.item.ItemType).values()}" class="form-check form-check-inline">
+            <input type="radio" th:field="*{item.itemType}" th:value="${type.name()}"
+                   class="form-check-input" disabled>
+            <label th:for="${#ids.prev('itemType')}" th:text="${type.description}"
+                   class="form-check-label">
+                BOOK
+            </label>
+        </div>
+    </div>
+
     <div class="row">
         <div class="col">
             <button class="w-100 btn btn-primary btn-lg"


### PR DESCRIPTION
### 작업 내용
- 상품 종류를 선택하는 라디오 버튼 기능 구현
- enum(ItemType) 값을 기반으로 th:each로 반복 생성
- th:field와 th:value를 활용한 자동 바인딩 및 선택 상태 표시
- 등록 폼(addForm.html), 수정 폼(editForm.html), 상세 페이지(item.html)에 라디오 버튼 적용
- 상세 페이지는 th:object 없이 ${item.itemType}으로 직접 바인딩

### 주요 변경점
- 라디오 버튼은 선택이 보장되므로 별도 hidden 필드 필요 없음
- 타임리프가 자동으로 checked 속성 처리
- label의 for 속성은 #ids.prev를 통해 동적으로 연결됨

### 참고
- enum을 직접 사용하는 방식(${T(...)})도 가능하지만, 유지보수 측면에서 @ModelAttribute 방식 권장
